### PR TITLE
Put the issue template instructions into a comment

### DIFF
--- a/.github/ISSUE_TEMPLATE/generic_issue.md
+++ b/.github/ISSUE_TEMPLATE/generic_issue.md
@@ -3,6 +3,7 @@ name: New issue
 about: Creates a public issue to track feedback on the Project Maturity Model. 
 ---
 
+<!--
 Instructions:
 Thanks for taking the time to participate in this discussion and help us build this program in the open. Please delete the
 below when creating a new issue. 
@@ -14,3 +15,4 @@ discussion or including a list of issues. Instead, please jump in on some of the
 are the conditions under which your issue can be closed? If there aren't clear conditions for closing the issue, it might
 be an open ended discussion... see 1. above. If you have a list of suggestions, please open several issues.
 3. Feel free to open pull requests with suggested changes to the policies we've proposed.
+-->


### PR DESCRIPTION
To prevent accidently linking in the mentioned issues I'm putting all the contents inside a comment. So if the user forgets to remove the instructions it won't show in the final issue, nor will it link in the issues mentioned.